### PR TITLE
Fix depth parsing for decimal values

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -7,7 +7,8 @@ from skimage import io
 def parse_depth_from_filename(filename):
     """
     Extract depth information from the filename.
-    Supports optional units like 'um', 'micron', or 'microns'.
+    Supports optional units like 'um', 'micron', or 'microns' and
+    handles integer or decimal values.
     
     Args:
         filename (str): The filename containing depth information
@@ -15,7 +16,7 @@ def parse_depth_from_filename(filename):
     Returns:
         float: The parsed depth value in microns
     """
-    match = re.search(r'(\d+)\s*(?:um|micron(?:s)?)?', filename, re.IGNORECASE)
+    match = re.search(r"(-?\d+(?:\.\d+)?)\s*(?:um|micron(?:s)?)?", filename, re.IGNORECASE)
     if match:
         return float(match.group(1))
     else:

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,18 @@
+import pytest
+from data_loader import parse_depth_from_filename
+
+
+def test_parse_depth_integer():
+    filename = "sample_5micron_deep.jpg"
+    assert parse_depth_from_filename(filename) == 5.0
+
+
+def test_parse_depth_decimal():
+    filename = "sample_7.5um.png"
+    assert parse_depth_from_filename(filename) == pytest.approx(7.5)
+
+
+def test_parse_depth_missing_raises():
+    filename = "sample_without_depth.jpg"
+    with pytest.raises(ValueError):
+        parse_depth_from_filename(filename)


### PR DESCRIPTION
## Summary
- handle decimal depth values in data_loader.parse_depth_from_filename
- add unit tests covering integer, decimal, and missing depth cases

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68953018ba2c83238e8d8f8477043927