### PR TITLE
Add tests for parse_depth parsing

### DIFF
--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import pytest
+
+# Ensure the repository root is on the path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from data_loader import parse_depth_from_filename
+
+
+def test_parse_depth_um():
+    assert parse_depth_from_filename('slice_10um.jpg') == 10.0
+
+
+def test_parse_depth_micron():
+    assert parse_depth_from_filename('slice_5micron.png') == 5.0
+
+
+def test_parse_depth_microns():
+    assert parse_depth_from_filename('slice_20microns.tif') == 20.0
+
+
+def test_parse_depth_missing_value():
+    with pytest.raises(ValueError):
+        parse_depth_from_filename('slice_no_depth.png')


### PR DESCRIPTION
## Summary
- add unit tests for `parse_depth_from_filename` with various unit suffixes
- ensure error raised when no depth value present

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895332adccc8323b63d4b283694e2ec